### PR TITLE
Use updated bap-ida-python

### DIFF
--- a/lib/bap_ida/bap_ida.ml
+++ b/lib/bap_ida/bap_ida.ml
@@ -170,7 +170,7 @@ module Ida = struct
     Command.create
       `python
       ~script:"
-from bap_ida_python.utils.ida import dump_symbol_info
+from bap.utils.ida import dump_symbol_info
 dump_symbol_info('$output')
 idc.Exit(0)"
       ~process:(fun name ->

--- a/plugins/emit_ida_script/emit_ida_script_main.ml
+++ b/plugins/emit_ida_script/emit_ida_script_main.ml
@@ -36,7 +36,7 @@ module Py = struct
   let prologue =
     {|
 from idautils import *
-from bap_ida_python.utils.ida import add_to_comment
+from bap.utils.ida import add_to_comment
 
 Wait()
 |}

--- a/plugins/ida/ida_main.ml
+++ b/plugins/ida/ida_main.ml
@@ -51,7 +51,7 @@ let register_source (module T : Target) =
 
 let loader_script =
   {|
-from bap_ida_python.utils.ida import dump_loader_info
+from bap.utils.ida import dump_loader_info
 dump_loader_info('$output')
 idc.Exit(0)
 |}


### PR DESCRIPTION
After these changes made [here](https://github.com/jaybosamiya/bap-ida-python/commit/b3bd5bd3a99054b853575022eb248244dce0e756) on `bap-ida-python`, this change uses the latest namespace
